### PR TITLE
fix build by adding the missing include

### DIFF
--- a/symmetri/include/symmetri/colors.hpp
+++ b/symmetri/include/symmetri/colors.hpp
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 namespace symmetri {
 
 using Token = uint32_t;


### PR DESCRIPTION
`uint32_t` is defined in `stdint.h` which was missing from this file, resulting in a failed compilation.